### PR TITLE
Much better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The mapping of these requests to commands is:
 
 ## Assumptions
 * The Mesos agent `hostname == ip`.
-* `dcosctl uncordon` simply removes a node from **all** maintenance windows in
-  the schedule, whether it is in draining mode or not.
 * The script needs cleartext/unauthed access to the Mesos master API.
+
+The cordon/uncordon process is intentionally *not* smart. Cordoning will add a
+new maintenance window for the node, and give up if one already exists.
+Uncordoning will always remove the node from any maintenance window.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ The mapping of these requests to commands is:
 
 ## Assumptions
 * The Mesos agent `hostname == ip`.
-* `dcosctl uncordon` removes a node from **all** maintenance windows in the
-  schedule.
+* `dcosctl uncordon` simply removes a node from **all** maintenance windows in
+  the schedule, whether it is in draining mode or not.
 * The script needs cleartext/unauthed access to the Mesos master API.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ The mapping of these requests to commands is:
 * `POST /maintenance/schedule` (remove from schedule) -> `dcosctl uncordon`
 
 ## Assumptions
-* The Mesos agent `hostname == ip`.
-* The script needs cleartext/unauthed access to the Mesos master API.
+The script needs cleartext/unauthed access to the Mesos master API.
 
 The cordon/uncordon process is intentionally *not* smart. Cordoning will add a
 new maintenance window for the node, and give up if one already exists.

--- a/dcosctl.py
+++ b/dcosctl.py
@@ -109,8 +109,9 @@ def up(mesos_url, machine_id):
     _request("POST", mesos_url, "machine/up", json=[machine_id])
 
 
-def _add_hostname_arg(parser):
+def _add_machine_args(parser):
     parser.add_argument("hostname", help="Hostname of node")
+    parser.add_argument("--ip", help="IP of node (if different from hostname)")
 
 
 def main(argv=sys.argv[1:]):
@@ -123,7 +124,7 @@ def main(argv=sys.argv[1:]):
 
     cordon_parser = subparsers.add_parser(
         "cordon", help="'Cordon' a node: schedule it for maintenance")
-    _add_hostname_arg(cordon_parser)
+    _add_machine_args(cordon_parser)
     cordon_parser.set_defaults(func=cordon)
     cordon_parser.add_argument(
         "--duration", type=float, default=3600.0,
@@ -133,22 +134,24 @@ def main(argv=sys.argv[1:]):
     uncordon_parser = subparsers.add_parser(
         "uncordon",
         help="'Uncordon' a node: remove it from the maintenance schedule")
-    _add_hostname_arg(uncordon_parser)
+    _add_machine_args(uncordon_parser)
     uncordon_parser.set_defaults(func=uncordon)
 
     drain_parser = subparsers.add_parser(
         "drain", help="'Drain' a node: mark the machine as down")
-    _add_hostname_arg(drain_parser)
+    _add_machine_args(drain_parser)
     drain_parser.set_defaults(func=drain)
 
     up_parser = subparsers.add_parser(
         "up", help="Mark a node as up: the opposite of drain")
-    _add_hostname_arg(up_parser)
+    _add_machine_args(up_parser)
     up_parser.set_defaults(func=up)
 
     args = parser.parse_args(argv)
 
-    machine_id = {"hostname": args.hostname, "ip": args.hostname}
+    ip = args.ip if args.ip else args.hostname
+    machine_id = {"hostname": args.hostname, "ip": ip}
+
     if args.func == cordon:
         args.func(args.mesos_url, machine_id, args.duration)
     else:

--- a/dcosctl.py
+++ b/dcosctl.py
@@ -118,8 +118,9 @@ def up(mesos_url, machine_id):
 
 
 def _add_machine_args(parser):
-    parser.add_argument("hostname", help="Hostname of node")
-    parser.add_argument("--ip", help="IP of node (if different from hostname)")
+    parser.add_argument("ip", help="IP of the node")
+    parser.add_argument(
+        "--hostname", help="Hostname of the node (if different from IP)")
 
 
 def main(argv=sys.argv[1:]):
@@ -157,8 +158,8 @@ def main(argv=sys.argv[1:]):
 
     args = parser.parse_args(argv)
 
-    ip = args.ip if args.ip else args.hostname
-    machine_id = {"hostname": args.hostname, "ip": ip}
+    hostname = args.hostname if args.hostname else args.ip
+    machine_id = {"ip": args.ip, "hostname": hostname}
 
     try:
         if args.func == cordon:

--- a/dcosctl.py
+++ b/dcosctl.py
@@ -66,9 +66,9 @@ def uncordon(args):
             found = True
 
         # Skip windows with no remaining machine IDs
-        if machine_ids:
+        if new_machine_ids:
             new_window = dict(window)
-            new_window["machine_ids"] = machine_ids
+            new_window["machine_ids"] = new_machine_ids
             new_windows.append(new_window)
 
     if not found:

--- a/dcosctl.py
+++ b/dcosctl.py
@@ -44,8 +44,15 @@ def cordon(mesos_url, machine_id, duration):
     # Get the existing maintenance schedule...
     schedule = _request("GET", mesos_url, "maintenance/schedule").json()
 
+    windows = schedule.setdefault("windows", [])
+    for window in windows:
+        if machine_id in window["machine_ids"]:
+            _log("ERROR: Machine already scheduled in a maintenance window, "
+                 "cannot schedule again")
+            return
+
     # Modify the windows in-place, appending the new node
-    schedule.setdefault("windows", []).append({
+    windows.append({
         "machine_ids": [machine_id],
         "unavailability": {
             "duration": _ns_time(duration),

--- a/dcosctl.py
+++ b/dcosctl.py
@@ -44,7 +44,7 @@ def cordon(args):
 
 
 def uncordon(args):
-    machine_id = {"hostname": args.hostname, "id": args.hostname}
+    machine_id = {"hostname": args.hostname, "ip": args.hostname}
 
     # Check if the node is in draining mode. Our 'uncordon' process doesn't
     # care whether or not this is the case, but it may be useful information


### PR DESCRIPTION
* If the schedule is empty
* Error if cordoning and the node is already scheduled for maintenance
* Error if uncordoning and the node wasn't scheduled for maintenance
* Warn if uncordoning and the node is not already in draining mode

Also:
* Allow hostname != ip